### PR TITLE
composer update for symfony 3.0+ packages

### DIFF
--- a/Command/StartCommand.php
+++ b/Command/StartCommand.php
@@ -15,6 +15,7 @@ use Certificationy\Certification\Loader;
 use Certificationy\Certification\Set;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -153,13 +154,13 @@ class StartCommand extends Command
         }
 
         if ($results) {
-            $tableHelper = $this->getHelper('table');
+            $tableHelper = new Table($output);
             $tableHelper
                 ->setHeaders(array('Question', 'Correct answer', 'Result'))
                 ->setRows($results)
             ;
 
-            $tableHelper->render($output);
+            $tableHelper->render();
 
             $output->writeln(
                 sprintf('<comment>Results</comment>: <error>errors: %s</error> - <info>correct: %s</info>', $set->getErrorsNumber(), $set->getValidNumber())

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "certificationy/symfony-pack": "dev-master",
         "certificationy/php-pack": "dev-master",
 
-        "herrera-io/phar-update": "~1.0",
+        "herrera-io/phar-update": "~2.0",
         "kherge/amend": "~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
This change is backward compatible, because Table was introduced in symfony/console 2.5, to replace TableHelper

http://symfony.com/doc/2.5/components/console/helpers/table.html