### PR TITLE
Results starting from 1 instead of 2

### DIFF
--- a/Command/StartCommand.php
+++ b/Command/StartCommand.php
@@ -143,7 +143,7 @@ class StartCommand extends Command
     {
         $results = array();
 
-        $questionCount = 1;
+        $questionCount = 0;
 
         foreach ($set->getQuestions() as $key => $question) {
             $isCorrect = $set->isCorrect($key);


### PR DESCRIPTION
Hi,

Small fix to start the results table at #1 instead of #2.