### PR TITLE
Fix Symfony console version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "symfony/console": "~3.2",
+        "symfony/console": ">=3.2.13 <3.3.0 || >=3.3.6 < 4.0.0",
         "certificationy/certificationy": "~2.0",
         "symfony/yaml": "~3.2",
         "certificationy/symfony-pack": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4496f8c784585a57d2a3ec57eda7fe88",
+    "content-hash": "28f963559ce5a8ca952ab806c9a0d7c7",
     "packages": [
         {
             "name": "certificationy/certificationy",
@@ -187,16 +187,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.5",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a97e45d98c59510f085fa05225a1acb74dfe0546"
+                "reference": "b0878233cb5c4391347e5495089c7af11b8e6201"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a97e45d98c59510f085fa05225a1acb74dfe0546",
-                "reference": "a97e45d98c59510f085fa05225a1acb74dfe0546",
+                "url": "https://api.github.com/repos/symfony/console/zipball/b0878233cb5c4391347e5495089c7af11b8e6201",
+                "reference": "b0878233cb5c4391347e5495089c7af11b8e6201",
                 "shasum": ""
             },
             "require": {
@@ -252,7 +252,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-03T13:19:36+00:00"
+            "time": "2017-07-29T21:27:59+00:00"
         },
         {
             "name": "symfony/debug",


### PR DESCRIPTION
When using symfony/console version between 3.2.0 and 3.2.12 and between 3.3.0 and 3.3.5, command arguments and options (`--number`, `--training`...) don't work when using setDefaultCommand.