### PR TITLE
Fix missing libzip-dev dependency for Dockerfile

### DIFF
--- a/docker/7.4/Dockerfile
+++ b/docker/7.4/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
  		zlib \
  		wget \
 		ca-certificates \
-		curl
+		curl \
+		libzip-dev
 
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -50,7 +50,7 @@ class StartCommand extends Command
             ->addOption('list', 'l', InputOption::VALUE_NONE, 'List categories')
             ->addOption('training', null, InputOption::VALUE_NONE, 'Training mode: the solution is displayed after each question')
             ->addOption('hide-multiple-choice', null, InputOption::VALUE_NONE, 'Should we hide the information that the question is multiple choice?')
-            ->addOption('config', 'c', InputOption::VALUE_OPTIONAL, 'Use custom config', null)
+            ->addOption('config', 'c', InputOption::VALUE_OPTIONAL, 'Use custom config', 'config.yml')
         ;
     }
 
@@ -64,6 +64,7 @@ class StartCommand extends Command
         $paths = Yaml::parse($fileContent);
 
         $yamlLoader = new Loader($paths);
+
         if ($input->getOption('list')) {
             $output->writeln($yamlLoader->categories());
 


### PR DESCRIPTION
When trying to build the image `docker-php-ext-install zip`will fail.
![image](https://user-images.githubusercontent.com/10506471/126346272-84c67289-c588-49e1-8403-c9f4eb02b94c.png)

Installing `libzip-dev` on the alpine image fixes this error. 
Might have to do with upgrading to the 7.4 php:fpm-alpine image, so that the dependency changed from zlib-dev to libzip-dev.
In this case we could remove the former.
Also it has to be a persistent dep, because the php extension will rely on it during runtime.

Also added a default value for the optional command option `config`. Not doing so will result in a fatal error since the parser constructor has no paths to work with.

On another note there is a yaml error in certificationy/php-pack
[missing dash](https://github.com/certificationy/php-pack/blob/6d6cdd82c28e1c71feda4c436648f6a1ea38c885/data/strings-patterns.yml#L117)
which leads do a `Duplicate key` exception from the symfony/yaml parser.
![Duplicate key "question"](https://user-images.githubusercontent.com/10506471/126364126-7b5172d4-45a0-4274-97ee-a030e3660365.png)

It is fixed in master already, so you might want to release 1.5 and/or upgrade the dependency. 

This PR should fix the problem in #56